### PR TITLE
feat - added delete post functionality

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model Post {
   authorId  String    @db.ObjectId
   tags      Tag[]     @relation
   comments  Comment[]
+  views     Int       @default(0)
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 }

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -1,6 +1,10 @@
 import prisma from "@/lib/db";
+import { getDataFromToken } from "@/lib/getDataFromToken";
 import { NextRequest, NextResponse } from "next/server";
 
+//@description     Get a single post
+//@route           GET /api/posts/[post.path]
+//@access          Not protected
 export async function GET(
   req: NextRequest,
   { params }: { params: { postId: string } }
@@ -30,31 +34,86 @@ export async function GET(
           },
         },
         _count: { select: { comments: true } },
-        // comments: {
-        //   take: 10,
-        //   orderBy: { createdAt: "desc" },
-        //   select: {
-        //     id: true,
-        //     content: true,
-        //     createdAt: true,
-        //     updatedAt: true,
-        //     replies: true,
-        //     author: {
-        //       select: {
-        //         id: true,
-        //         username: true,
-        //         avatar: true,
-        //         name: true,
-        //         createdAt: true,
-        //         updatedAt: true,
-        //       },
-        //     },
-        //   },
-        // },
       },
     });
 
+    if (post) {
+      await prisma.post.update({
+        where: { id: post.id },
+        data: { views: post.views + 1 }, // Increment the views by 1
+      });
+    } else {
+      return NextResponse.json(
+        { success: false, message: "Post not found!" },
+        { status: 404 }
+      );
+    }
+
     return NextResponse.json(post, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json({ message: error.message }, { status: 500 });
+  }
+}
+
+//@description     Delete a single post
+//@route           DELETE /api/posts/[post.path]
+//@access          protected
+export async function DELETE(req: NextRequest) {
+  try {
+    const postId = req.nextUrl.searchParams.get("id");
+    if (!postId) {
+      return NextResponse.json(
+        { success: false, message: "Invalid post ID!" },
+        { status: 404 }
+      );
+    }
+
+    const userID = await getDataFromToken(req);
+    if (!userID) {
+      return NextResponse.json(
+        { success: false, message: "You are not authorize!" },
+        { status: 401 }
+      );
+    }
+
+    const post = await prisma.post.findFirst({
+      where: { id: postId, authorId: userID },
+    });
+    if (!post) {
+      return NextResponse.json(
+        { success: false, message: "Post not found!" },
+        { status: 404 }
+      );
+    }
+
+    const deleteToComment = await prisma.comment.findMany({
+      where: { postId: post.id },
+    });
+
+    // Delete all comments and there replies associated with the post
+    for (const deleteId of deleteToComment) {
+      const repliesToDelete = await prisma.reply.findMany({
+        where: { commentId: deleteId.id },
+      });
+      for (const deleteReply of repliesToDelete) {
+        await prisma.reply.delete({
+          where: { id: deleteReply.id },
+        });
+      }
+
+      await prisma.comment.delete({
+        where: { id: deleteId.id },
+      });
+    }
+
+    await prisma.post.delete({
+      where: { id: post.id, authorId: userID },
+    });
+
+    return NextResponse.json(
+      { success: true, message: "Your post deleted successfully" },
+      { status: 200 }
+    );
   } catch (error: any) {
     return NextResponse.json({ message: error.message }, { status: 500 });
   }

--- a/src/components/posts/PostArticle.tsx
+++ b/src/components/posts/PostArticle.tsx
@@ -2,9 +2,20 @@
 
 import { TPost } from "@/lib/types";
 
-import { User } from "@nextui-org/react";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  User,
+  useDisclosure,
+} from "@nextui-org/react";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
 import React from "react";
 
 import ReactMarkdown from "react-markdown";
@@ -18,9 +29,38 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import Comments from "../comments/Comments";
 
 import moment from "moment";
-import Image from "next/image";
+import axios from "axios";
+import toast from "react-hot-toast";
+import { useAppSelector } from "@/hooks/reduxHooks";
+import { useMutation } from "@tanstack/react-query";
 
 const PostArticle = ({ post }: { post: TPost }) => {
+  const router = useRouter();
+
+  const { isOpen, onOpenChange, onOpen, onClose } = useDisclosure();
+
+  const { user } = useAppSelector((state) => state.auth);
+
+  const deletePost = async () => {
+    const { data } = await axios.delete(
+      `/api/posts/${post.path}?id=${post.id}`
+    );
+    return data;
+  };
+
+  const { mutate, isLoading } = useMutation(deletePost, {
+    onSuccess: (data) => {
+      toast.success(data.message);
+      console.log(data);
+      onClose();
+      router.push("/");
+    },
+    onError: (data: any) => {
+      toast.error(data.message);
+      console.log(data);
+    },
+  });
+
   return (
     <>
       <article className="pb-4">
@@ -36,22 +76,43 @@ const PostArticle = ({ post }: { post: TPost }) => {
               />
             </figure>
           )}
-          <User
-            name={post.author.name}
-            as={Link}
-            href={`/${post.author.username}`}
-            description={
-              <div className="text-default-500">
-                Posted on: (
-                {moment(post.updatedAt, moment.ISO_8601).format("DD MMM")} ){" "}
-                {moment(post.updatedAt, moment.ISO_8601, "DDMMMYYYY").fromNow()}
+          <div className="flex justify-between items-center">
+            <User
+              name={post.author.name}
+              as={Link}
+              href={`/${post.author.username}`}
+              description={
+                <div className="text-default-500">
+                  Posted on: (
+                  {moment(post.createdAt, moment.ISO_8601).format("DD MMM")} ){" "}
+                  {moment(
+                    post.createdAt,
+                    moment.ISO_8601,
+                    "DDMMMYYYY"
+                  ).fromNow()}
+                </div>
+              }
+              avatarProps={{
+                src: `${post.author.avatar}`,
+              }}
+              className=""
+            />
+            {user && user.id === post.author.id ? (
+              <div>
+                <Button variant="light" className="mr-2" size="sm">
+                  Edit
+                </Button>
+                <Button
+                  variant="light"
+                  color="danger"
+                  size="sm"
+                  onClick={onOpen}
+                >
+                  Delete
+                </Button>
               </div>
-            }
-            avatarProps={{
-              src: `${post.author.avatar}`,
-            }}
-            className=""
-          />
+            ) : null}
+          </div>
           <h1 className="mb-6 mt-4 scroll-m-20 lg:text-5xl md:text-4xl text-3xl sm:font-extrabold font-bold tracking-tight">
             {post.title}
           </h1>
@@ -71,6 +132,44 @@ const PostArticle = ({ post }: { post: TPost }) => {
       </article>
       <hr className="pb-8" />
       <Comments post={post} />
+
+      {/* ===DELETE MODAL=== */}
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        placement="center"
+        radius="sm"
+      >
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>
+                Are you sure you want to delete this post?
+              </ModalHeader>
+              <ModalBody>
+                <p>
+                  You cannot undo this action, perhaps you just want to edit
+                  instead?
+                </p>
+              </ModalBody>
+              <ModalFooter>
+                <Button
+                  color="danger"
+                  onPress={() => mutate()}
+                  radius="sm"
+                  isDisabled={isLoading}
+                  isLoading={isLoading}
+                >
+                  {isLoading ? "Deleting" : "Yes, Delete"}
+                </Button>
+                <Button onPress={onClose} radius="sm">
+                  No, Cancel
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
     </>
   );
 };


### PR DESCRIPTION
## Overview

This pull request adds the functionality to delete a single post in the application. Users with the appropriate authorization can delete their own posts. When a post is deleted, it also deletes all associated comments and their replies.

### Changes Made

- Added a new DELETE route (`/api/posts/[post.path]`) to handle post deletion.
- Implemented server-side logic to validate the request and ensure the user has the necessary authorization to delete the post.
- Deleted all comments and their associated replies linked to the post being deleted.
- Updated the client-side code to utilize React Query and display a confirmation modal for post deletion.

### How to Test

1. Log in to the application with valid credentials.
2. Navigate to a post you want to delete.
3. Click the "Delete" button.
4. A confirmation modal will appear.
5. Click "Yes, Delete" to delete the post (or "No, Cancel" to abort).
6. Observe the behavior, and ensure the post, along with its comments and replies, is successfully deleted.

### Additional Information

- This feature was implemented with a focus on user experience and data consistency.
- Error handling and feedback messages are provided to users during the deletion process.
- Client-side code uses React Query for data management and Axios for making API requests.
